### PR TITLE
fix build from ros2 for new subdirectory method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(sweep_ros)
 
 find_package(ament_cmake REQUIRED)
 
-find_package(Sweep REQUIRED)
+find_package(Sweep)
 find_package(Threads REQUIRED)
 find_package(PCL REQUIRED)
 


### PR DESCRIPTION
make sweep not required, it is needed for linking but will get added by subdirectory